### PR TITLE
Remove extraneous conditional from line 32

### DIFF
--- a/sublimate/sublimate.py
+++ b/sublimate/sublimate.py
@@ -29,7 +29,7 @@ class victimNode:
                     break
 
             # If it is the new worst path, insert at end
-            else(i == len(self.compromisePaths)):
+            else:
                 self.compromisePaths.append(path)
 
     def CalculateScore(self):


### PR DESCRIPTION
Basically what the title says, the program would error because `else` statements can't have conditional logic attached to them.

See #3 